### PR TITLE
guiconstants.h: Fix datadirpath / registry issue

### DIFF
--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -44,9 +44,9 @@ static const int MAX_URI_LENGTH = 255;
 /* Number of frames in spinner animation */
 #define SPINNER_FRAMES 35
 
-#define QAPP_ORG_NAME "Bitcoin"
-#define QAPP_ORG_DOMAIN "bitcoin.org"
-#define QAPP_APP_NAME_DEFAULT "Bitcoin-Qt"
-#define QAPP_APP_NAME_TESTNET "Bitcoin-Qt-testnet"
+#define QAPP_ORG_NAME "Namecoin"
+#define QAPP_ORG_DOMAIN "namecoin.org"
+#define QAPP_APP_NAME_DEFAULT "Namecoin-Qt"
+#define QAPP_APP_NAME_TESTNET "Namecoin-Qt-testnet"
 
 #endif // BITCOIN_QT_GUICONSTANTS_H


### PR DESCRIPTION
On Windows Namecore modifies/creates a Bitcoin registry entry (strDataDir) making Bitcoin disfunctional (if the Namecoin folder is not yet present).

