### PR TITLE
.rc files: Proper task names

### DIFF
--- a/src/bitcoin-cli-res.rc
+++ b/src/bitcoin-cli-res.rc
@@ -16,14 +16,14 @@ BEGIN
     BEGIN
         BLOCK "040904E4" // U.S. English - multilingual (hex)
         BEGIN
-            VALUE "CompanyName",        "Bitcoin"
-            VALUE "FileDescription",    "bitcoin-cli (JSON-RPC client for Bitcoin Core)"
+            VALUE "CompanyName",        "Namecoin"
+            VALUE "FileDescription",    "namecoin-cli (JSON-RPC client for Bitcoin Core)"
             VALUE "FileVersion",        VER_FILEVERSION_STR
-            VALUE "InternalName",       "bitcoin-cli"
+            VALUE "InternalName",       "namecoin-cli"
             VALUE "LegalCopyright",     COPYRIGHT_STR
             VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
-            VALUE "OriginalFilename",   "bitcoin-cli.exe"
-            VALUE "ProductName",        "bitcoin-cli"
+            VALUE "OriginalFilename",   "namecoin-cli.exe"
+            VALUE "ProductName",        "Namecore"
             VALUE "ProductVersion",     VER_PRODUCTVERSION_STR
         END
     END

--- a/src/bitcoin-cli-res.rc
+++ b/src/bitcoin-cli-res.rc
@@ -23,7 +23,7 @@ BEGIN
             VALUE "LegalCopyright",     COPYRIGHT_STR
             VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
             VALUE "OriginalFilename",   "namecoin-cli.exe"
-            VALUE "ProductName",        "Namecore"
+            VALUE "ProductName",        "Namecoin Core"
             VALUE "ProductVersion",     VER_PRODUCTVERSION_STR
         END
     END

--- a/src/bitcoin-tx-res.rc
+++ b/src/bitcoin-tx-res.rc
@@ -16,14 +16,14 @@ BEGIN
     BEGIN
         BLOCK "040904E4" // U.S. English - multilingual (hex)
         BEGIN
-            VALUE "CompanyName",        "Bitcoin"
-            VALUE "FileDescription",    "bitcoin-tx (CLI Bitcoin transaction editor utility)"
+            VALUE "CompanyName",        "Namecoin"
+            VALUE "FileDescription",    "namecoin-tx (CLI Namecoin transaction editor utility)"
             VALUE "FileVersion",        VER_FILEVERSION_STR
-            VALUE "InternalName",       "bitcoin-tx"
+            VALUE "InternalName",       "namecoin-tx"
             VALUE "LegalCopyright",     COPYRIGHT_STR
             VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
-            VALUE "OriginalFilename",   "bitcoin-tx.exe"
-            VALUE "ProductName",        "bitcoin-tx"
+            VALUE "OriginalFilename",   "namecoin-tx.exe"
+            VALUE "ProductName",        "Namecore"
             VALUE "ProductVersion",     VER_PRODUCTVERSION_STR
         END
     END

--- a/src/bitcoin-tx-res.rc
+++ b/src/bitcoin-tx-res.rc
@@ -23,7 +23,7 @@ BEGIN
             VALUE "LegalCopyright",     COPYRIGHT_STR
             VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
             VALUE "OriginalFilename",   "namecoin-tx.exe"
-            VALUE "ProductName",        "Namecore"
+            VALUE "ProductName",        "Namecoin Core"
             VALUE "ProductVersion",     VER_PRODUCTVERSION_STR
         END
     END

--- a/src/bitcoind-res.rc
+++ b/src/bitcoind-res.rc
@@ -23,7 +23,7 @@ BEGIN
             VALUE "LegalCopyright",     COPYRIGHT_STR
             VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
             VALUE "OriginalFilename",   "namecoind.exe"
-            VALUE "ProductName",        "Namecore"
+            VALUE "ProductName",        "Namecoin Core"
             VALUE "ProductVersion",     VER_PRODUCTVERSION_STR
         END
     END

--- a/src/bitcoind-res.rc
+++ b/src/bitcoind-res.rc
@@ -16,14 +16,14 @@ BEGIN
     BEGIN
         BLOCK "040904E4" // U.S. English - multilingual (hex)
         BEGIN
-            VALUE "CompanyName",        "Bitcoin"
-            VALUE "FileDescription",    "bitcoind (Bitcoin node with a JSON-RPC server)"
+            VALUE "CompanyName",        "Namecoin"
+            VALUE "FileDescription",    "namecoind (Namecoin node with a JSON-RPC server)"
             VALUE "FileVersion",        VER_FILEVERSION_STR
-            VALUE "InternalName",       "bitcoind"
+            VALUE "InternalName",       "namecoind"
             VALUE "LegalCopyright",     COPYRIGHT_STR
             VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
-            VALUE "OriginalFilename",   "bitcoind.exe"
-            VALUE "ProductName",        "bitcoind"
+            VALUE "OriginalFilename",   "namecoind.exe"
+            VALUE "ProductName",        "Namecore"
             VALUE "ProductVersion",     VER_PRODUCTVERSION_STR
         END
     END

--- a/src/qt/res/bitcoin-qt-res.rc
+++ b/src/qt/res/bitcoin-qt-res.rc
@@ -25,7 +25,7 @@ BEGIN
             VALUE "LegalCopyright",     COPYRIGHT_STR
             VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
             VALUE "OriginalFilename",   "namecoin-qt.exe"
-            VALUE "ProductName",        "Namecore"
+            VALUE "ProductName",        "Namecoin Core"
             VALUE "ProductVersion",     VER_PRODUCTVERSION_STR
         END
     END


### PR DESCRIPTION
At least on windows these are displayed in the task manager.
I left Namecore as product name as is the case in the Qt .rc file.